### PR TITLE
Remove GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [hannobraun]


### PR DESCRIPTION
I've updated my GitHub Sponsors profile to be focused on non-embedded
thing, and I don't want to mislead anyone.