### PR TITLE
PR #142 part deux: replace embedded-time with fugit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = [
 
 [package]
 name    = "stepper"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Hanno Braun <hanno@braun-embedded.com>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 [dependencies]
 embedded-hal  = "=1.0.0-alpha.6"
-embedded-time = "0.12.0"
 fugit         = "0.3.5"
 fugit-timer   = "0.1.3"
 nb            = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 [dependencies]
 embedded-hal  = "=1.0.0-alpha.6"
 embedded-time = "0.12.0"
+fugit         = "0.3.5"
+fugit-timer   = "0.1.3"
 nb            = "1.0.0"
 paste         = "1.0.3"
 ramp-maker    = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
     "Hanno Braun <hanno@braun-embedded.com>",
     "Jesse Braham <jesse@beta7.io>",
 ]
-edition = "2021"
+edition = "2018"
 
 description = "Universal Stepper Motor Interface"
 homepage    = "https://flott-motion.org/"

--- a/drivers/drv8825/Cargo.toml
+++ b/drivers/drv8825/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "drv8825"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Hanno Braun <hanno@braun-embedded.com>",
     "Jesse Braham <jesse@beta7.io>",
@@ -15,7 +15,7 @@ categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 
 [dependencies.stepper]
-version          = "0.5.0"
+version          = "0.6.0"
 path             = "../.."
 default-features = false
 features         = ["drv8825"]

--- a/drivers/stspin220/Cargo.toml
+++ b/drivers/stspin220/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "stspin220"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Hanno Braun <hanno@braun-embedded.com>",
     "Jesse Braham <jesse@beta7.io>",
@@ -15,7 +15,7 @@ categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 
 [dependencies.stepper]
-version          = "0.5.0"
+version          = "0.6.0"
 path             = "../.."
 default-features = false
 features         = ["stspin220"]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,18 +1,9 @@
 //! Compatibility code to help use Stepper on more platforms
 
-use core::{
-    convert::{Infallible, TryFrom},
-    fmt, ops,
-};
+use core::fmt;
 
-use embedded_hal::{digital::blocking::OutputPin, timer::nb::CountDown};
-use embedded_hal_stable::{
-    digital::v2::OutputPin as StableOutputPin,
-    timer::CountDown as StableCountDown,
-};
-use embedded_time::{
-    duration::Duration as _, rate::Fraction, ConversionError, TimeInt,
-};
+use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal_stable::digital::v2::OutputPin as StableOutputPin;
 
 /// Wrapper around a pin
 ///
@@ -35,94 +26,5 @@ where
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
         self.0.set_high()
-    }
-}
-
-/// Wrapper around a timer
-///
-/// Provides an implementation of [`embedded_hal::timer::nb::CountDown`] (that
-/// is, the `CountDown` from the latest alpha version of `embedded-hal`) for all
-/// types that implement `CountDown` from the latest stable version of
-/// `embedded-hal`.
-pub struct Timer<T, const FREQ: u32>(pub T);
-
-impl<T, const FREQ: u32> CountDown for Timer<T, FREQ>
-where
-    T: StableCountDown,
-{
-    type Error = Infallible;
-
-    type Time = Ticks<<T as StableCountDown>::Time, FREQ>;
-
-    fn start<Ticks>(&mut self, ticks: Ticks) -> Result<(), Self::Error>
-    where
-        Ticks: Into<Self::Time>,
-    {
-        let ticks = ticks.into();
-        self.0.start(ticks.0);
-        Ok(())
-    }
-
-    fn wait(&mut self) -> nb::Result<(), Self::Error> {
-        match self.0.wait() {
-            Ok(()) => Ok(()),
-            Err(nb::Error::WouldBlock) => return Err(nb::Error::WouldBlock),
-            Err(nb::Error::Other(_)) => {
-                unreachable!("Caught error from infallible method")
-            }
-        }
-    }
-}
-
-/// Timer ticks for a timer with frequency `FREQ`
-///
-/// Provides conversions from various duration types from `embedded-time` into
-/// timer ticks for a timer with the frequency defined by `FREQ`. Since this is
-/// a fully generic type that has no knowledge of the timers it is being used
-/// with, it is the user's responsibility to make sure the resulting value is
-/// valid for the timer.
-///
-/// `FREQ` is defined in Hz.
-pub struct Ticks<T, const FREQ: u32>(pub T);
-
-macro_rules! impl_conversions {
-    ($($duration:ident,)*) => {
-        $(
-            impl<T, const FREQ: u32> TryFrom<embedded_time::duration::$duration>
-                for Ticks<T, FREQ>
-            where
-                T: TimeInt,
-            {
-                type Error = ConversionError;
-
-                fn try_from(duration: embedded_time::duration::$duration)
-                    -> Result<Self, Self::Error>
-                {
-                    let ticks =
-                        duration.to_generic::<T>(Fraction::new(1, FREQ))?;
-                    Ok(Self(ticks.integer()))
-                }
-            }
-        )*
-    };
-}
-
-impl_conversions!(
-    Nanoseconds,
-    Microseconds,
-    Milliseconds,
-    Seconds,
-    Minutes,
-    Hours,
-);
-
-impl<T, const FREQ: u32> ops::Sub for Ticks<T, FREQ>
-where
-    T: TimeInt + ops::Sub,
-{
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Ticks(self.0 - other.0)
     }
 }

--- a/src/drivers/dq542ma.rs
+++ b/src/drivers/dq542ma.rs
@@ -12,7 +12,7 @@
 use core::convert::Infallible;
 
 use embedded_hal::digital::blocking::OutputPin;
-use embedded_time::duration::Nanoseconds;
+use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::traits::{
     EnableDirectionControl, EnableStepControl, SetDirection, Step as StepTrait,
@@ -61,7 +61,7 @@ where
     Dir: OutputPin<Error = OutputPinError>,
 {
     // https://wiki.linuxcnc.org/cgi-bin/wiki.pl?Stepper_Drive_Timing
-    const SETUP_TIME: Nanoseconds = Nanoseconds(500);
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(500);
 
     type Dir = Dir;
     type Error = Infallible;
@@ -91,7 +91,7 @@ where
     Step: OutputPin<Error = OutputPinError>,
 {
     // https://wiki.linuxcnc.org/cgi-bin/wiki.pl?Stepper_Drive_Timing
-    const PULSE_LENGTH: Nanoseconds = Nanoseconds(5050);
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds::from_ticks(5050);
 
     type Step = Step;
     type Error = Infallible;

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -12,7 +12,7 @@
 use core::convert::Infallible;
 
 use embedded_hal::digital::{blocking::OutputPin, PinState};
-use embedded_time::duration::Nanoseconds;
+use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::{
     step_mode::StepMode32,
@@ -97,8 +97,8 @@ where
 {
     // 7.6 Timing Requirements (page 7)
     // https://www.ti.com/lit/ds/symlink/drv8825.pdf
-    const SETUP_TIME: Nanoseconds = Nanoseconds(650);
-    const HOLD_TIME: Nanoseconds = Nanoseconds(650);
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(650);
+    const HOLD_TIME: Nanoseconds = Nanoseconds::from_ticks(650);
 
     type Error = OutputPinError;
     type StepMode = StepMode32;
@@ -165,7 +165,7 @@ where
 {
     // 7.6 Timing Requirements (page 7)
     // https://www.ti.com/lit/ds/symlink/drv8825.pdf
-    const SETUP_TIME: Nanoseconds = Nanoseconds(650);
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(650);
 
     type Dir = Dir;
     type Error = Infallible;
@@ -206,7 +206,7 @@ where
 {
     // 7.6 Timing Requirements (page 7)
     // https://www.ti.com/lit/ds/symlink/drv8825.pdf
-    const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds::from_ticks(1900);
 
     type Step = Step;
     type Error = Infallible;

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -12,7 +12,7 @@
 use core::convert::Infallible;
 
 use embedded_hal::digital::{blocking::OutputPin, PinState};
-use embedded_time::duration::Nanoseconds;
+use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::{
     step_mode::StepMode256,
@@ -109,8 +109,8 @@ where
     StepMode3: OutputPin<Error = OutputPinError>,
     DirMode4: OutputPin<Error = OutputPinError>,
 {
-    const SETUP_TIME: Nanoseconds = Nanoseconds(1_000);
-    const HOLD_TIME: Nanoseconds = Nanoseconds(100_000);
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(1_000);
+    const HOLD_TIME: Nanoseconds = Nanoseconds::from_ticks(100_000);
 
     type Error = OutputPinError;
     type StepMode = StepMode256;
@@ -195,7 +195,7 @@ impl<
 where
     DirMode4: OutputPin<Error = OutputPinError>,
 {
-    const SETUP_TIME: Nanoseconds = Nanoseconds(100);
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(100);
 
     type Dir = DirMode4;
     type Error = Infallible;
@@ -249,7 +249,7 @@ impl<
 where
     StepMode3: OutputPin<Error = OutputPinError>,
 {
-    const PULSE_LENGTH: Nanoseconds = Nanoseconds(100);
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds::from_ticks(100);
 
     type Step = StepMode3;
     type Error = Infallible;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! #     > {
 //! #
 //! use stepper::{
-//!     embedded_time::duration::Nanoseconds,
+//!     fugit::NanosDurationU32 as Nanoseconds,
 //!     motion_control, ramp_maker,
 //!     Direction, Stepper,
 //! };
@@ -164,7 +164,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 pub extern crate embedded_hal;
-pub extern crate embedded_time;
+pub extern crate fugit;
 pub extern crate ramp_maker;
 
 pub mod compat;

--- a/src/motion_control/conversion.rs
+++ b/src/motion_control/conversion.rs
@@ -1,3 +1,5 @@
+use fugit::TimerDurationU32 as TimerDuration;
+
 /// Converts delay values from RampMaker into timer ticks
 ///
 /// RampMaker is agnostic over the units used, and the unit of the timer ticks
@@ -6,13 +8,13 @@
 /// environment.
 ///
 /// The `Delay` parameter specifies the type of delay value used by RampMaker.
-pub trait DelayToTicks<Delay> {
-    /// The timer ticks the delay is being converted into
-    type Ticks;
-
+pub trait DelayToTicks<Delay, const TIMER_HZ: u32> {
     /// The error that can happen during conversion
     type Error;
 
-    /// Convert delay value into timer ticks
-    fn delay_to_ticks(&self, delay: Delay) -> Result<Self::Ticks, Self::Error>;
+    /// Convert delay value into timer duration
+    fn delay_to_ticks(
+        &self,
+        delay: Delay,
+    ) -> Result<TimerDuration<TIMER_HZ>, Self::Error>;
 }

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -8,7 +8,6 @@ pub enum Error<
     StepPinUnavailable,
     StepError,
     TimerError,
-    NanosecondsToTicksError,
     DelayToTicksError,
 > {
     /// Error while setting direction
@@ -16,25 +15,15 @@ pub enum Error<
         crate::SignalError<
             SetDirectionPinUnavailable,
             SetDirectionError,
-            NanosecondsToTicksError,
             TimerError,
         >,
     ),
 
     /// Error while stepping the motor
-    Step(
-        crate::SignalError<
-            StepPinUnavailable,
-            StepError,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
-    ),
+    Step(crate::SignalError<StepPinUnavailable, StepError, TimerError>),
 
     /// Error while converting between time formats
-    TimeConversion(
-        TimeConversionError<NanosecondsToTicksError, DelayToTicksError>,
-    ),
+    TimeConversion(TimeConversionError<DelayToTicksError>),
 
     /// Error while waiting for a step to finish
     StepDelay(TimerError),
@@ -42,10 +31,7 @@ pub enum Error<
 
 /// An error occurred while converting between time formats
 #[derive(Debug, Eq, PartialEq)]
-pub enum TimeConversionError<NanosecondsToTicksError, DelayToTicksError> {
-    /// Error converting from nanoseconds to timer ticks
-    NanosecondsToTicks(NanosecondsToTicksError),
-
+pub enum TimeConversionError<DelayToTicksError> {
     /// Error converting from RampMaker delay value to timer ticks
     DelayToTicks(DelayToTicksError),
 }

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -408,7 +408,7 @@ where
 // Blanket implementation of `EnableMotionControl` for all STEP/DIR stepper
 // drivers.
 impl<Driver, Timer, Profile, Convert, const TIMER_HZ: u32>
-    EnableMotionControl<(Timer, Profile, Convert)> for Driver
+    EnableMotionControl<(Timer, Profile, Convert), TIMER_HZ> for Driver
 where
     Driver: SetDirection + Step,
     Profile: MotionProfile,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -243,7 +243,10 @@ where
     /// [`Stepper::step`]: crate::Stepper::step
     pub fn step(
         &mut self,
-    ) -> Result<StepFuture<RefMut<Driver>, RefMut<Timer>>, BusyError<Infallible>>
+    ) -> Result<
+        StepFuture<RefMut<Driver>, RefMut<Timer>, TIMER_HZ>,
+        BusyError<Infallible>,
+    >
     where
         Driver: Step,
         Timer: TimerTrait<TIMER_HZ>,

--- a/src/stepper/error.rs
+++ b/src/stepper/error.rs
@@ -7,22 +7,9 @@ use crate::motion_control;
 ///
 /// [`Stepper`]: crate::Stepper
 #[derive(Debug, Eq, PartialEq)]
-pub enum Error<
-    PinUnavailableError,
-    PinError,
-    NanosecondsToTicksError,
-    DelayToTicksError,
-    TimerError,
-> {
+pub enum Error<PinUnavailableError, PinError, DelayToTicksError, TimerError> {
     /// A signal error
-    Signal(
-        SignalError<
-            PinUnavailableError,
-            PinError,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
-    ),
+    Signal(SignalError<PinUnavailableError, PinError, TimerError>),
 
     /// A motion control error
     MotionControl(
@@ -32,54 +19,23 @@ pub enum Error<
             PinUnavailableError,
             PinError,
             TimerError,
-            NanosecondsToTicksError,
             DelayToTicksError,
         >,
     ),
 }
 
-impl<
-        PinUnavailableError,
-        PinError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-        TimerError,
-    >
-    From<
-        SignalError<
-            PinUnavailableError,
-            PinError,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
-    >
-    for Error<
-        PinUnavailableError,
-        PinError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-        TimerError,
-    >
+impl<PinUnavailableError, PinError, DelayToTicksError, TimerError>
+    From<SignalError<PinUnavailableError, PinError, TimerError>>
+    for Error<PinUnavailableError, PinError, DelayToTicksError, TimerError>
 {
     fn from(
-        err: SignalError<
-            PinUnavailableError,
-            PinError,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
+        err: SignalError<PinUnavailableError, PinError, TimerError>,
     ) -> Self {
         Self::Signal(err)
     }
 }
 
-impl<
-        PinUnavailableError,
-        PinError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-        TimerError,
-    >
+impl<PinUnavailableError, PinError, DelayToTicksError, TimerError>
     From<
         motion_control::Error<
             PinUnavailableError,
@@ -87,17 +43,9 @@ impl<
             PinUnavailableError,
             PinError,
             TimerError,
-            NanosecondsToTicksError,
             DelayToTicksError,
         >,
-    >
-    for Error<
-        PinUnavailableError,
-        PinError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-        TimerError,
-    >
+    > for Error<PinUnavailableError, PinError, DelayToTicksError, TimerError>
 {
     fn from(
         err: motion_control::Error<
@@ -106,7 +54,6 @@ impl<
             PinUnavailableError,
             PinError,
             TimerError,
-            NanosecondsToTicksError,
             DelayToTicksError,
         >,
     ) -> Self {
@@ -116,12 +63,7 @@ impl<
 
 /// An error that can occur while using this API
 #[derive(Debug, Eq, PartialEq)]
-pub enum SignalError<
-    PinUnavailableError,
-    PinError,
-    NanosecondsToTicksError,
-    TimerError,
-> {
+pub enum SignalError<PinUnavailableError, PinError, TimerError> {
     /// A pin was not accessible
     PinUnavailable(PinUnavailableError),
 
@@ -129,9 +71,6 @@ pub enum SignalError<
     ///
     /// [`OutputPin`]: embedded_hal::digital::blocking::OutputPin
     Pin(PinError),
-
-    /// An error occurred while converting nanoseconds to timer ticks
-    NanosecondsToTicks(NanosecondsToTicksError),
 
     /// An error originated from working with a timer
     Timer(TimerError),

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -293,7 +293,7 @@ impl<Driver> Stepper<Driver> {
     pub fn step<'r, Timer, const TIMER_HZ: u32>(
         &'r mut self,
         timer: &'r mut Timer,
-    ) -> StepFuture<RefMut<'r, Driver>, RefMut<'r, Timer>>
+    ) -> StepFuture<RefMut<'r, Driver>, RefMut<'r, Timer>, TIMER_HZ>
     where
         Driver: Step,
         Timer: TimerTrait<TIMER_HZ>,

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -334,12 +334,12 @@ impl<Driver> Stepper<Driver> {
     /// hardware support, or through the aforementioned software fallback. It
     /// might no longer be available, once motion control support has been
     /// enabled.
-    pub fn enable_motion_control<Resources>(
+    pub fn enable_motion_control<Resources, const TIMER_HZ: u32>(
         self,
         res: Resources,
     ) -> Stepper<Driver::WithMotionControl>
     where
-        Driver: EnableMotionControl<Resources>,
+        Driver: EnableMotionControl<Resources, TIMER_HZ>,
     {
         Stepper {
             driver: self.driver.enable_motion_control(res),

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -1,10 +1,8 @@
-use core::{
-    convert::{TryFrom, TryInto as _},
-    task::Poll,
-};
+use core::task::Poll;
 
-use embedded_hal::{digital::blocking::OutputPin, timer::nb as timer};
-use embedded_time::duration::Nanoseconds;
+use embedded_hal::digital::blocking::OutputPin;
+use fugit::TimerDurationU32 as TimerDuration;
+use fugit_timer::Timer as TimerTrait;
 
 use crate::{traits::SetDirection, Direction};
 
@@ -18,18 +16,18 @@ use super::SignalError;
 ///
 /// [`Stepper::set_direction`]: crate::Stepper::set_direction
 #[must_use]
-pub struct SetDirectionFuture<Driver, Timer> {
+pub struct SetDirectionFuture<Driver, Timer, const TIMER_HZ: u32> {
     direction: Direction,
     driver: Driver,
     timer: Timer,
     state: State,
 }
 
-impl<Driver, Timer> SetDirectionFuture<Driver, Timer>
+impl<Driver, Timer, const TIMER_HZ: u32>
+    SetDirectionFuture<Driver, Timer, TIMER_HZ>
 where
     Driver: SetDirection,
-    Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds>,
+    Timer: TimerTrait<TIMER_HZ>,
 {
     /// Create new instance of `SetDirectionFuture`
     ///
@@ -66,7 +64,6 @@ where
             SignalError<
                 Driver::Error,
                 <Driver::Dir as OutputPin>::Error,
-                <Timer::Time as TryFrom<Nanoseconds>>::Error,
                 Timer::Error,
             >,
         >,
@@ -88,9 +85,8 @@ where
                         .map_err(|err| SignalError::Pin(err))?,
                 }
 
-                let ticks: Timer::Time = Driver::SETUP_TIME
-                    .try_into()
-                    .map_err(|err| SignalError::NanosecondsToTicks(err))?;
+                let ticks: TimerDuration<TIMER_HZ> =
+                    Driver::SETUP_TIME.convert();
                 self.timer
                     .start(ticks)
                     .map_err(|err| SignalError::Timer(err))?;
@@ -124,7 +120,6 @@ where
         SignalError<
             Driver::Error,
             <Driver::Dir as OutputPin>::Error,
-            <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,
     > {

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -64,7 +64,6 @@ where
             SignalError<
                 Driver::Error,
                 <Driver::Step as OutputPin>::Error,
-                <Timer::Time as TryFrom<Nanoseconds>>::Error,
                 Timer::Error,
             >,
         >,
@@ -123,7 +122,6 @@ where
         SignalError<
             Driver::Error,
             <Driver::Step as OutputPin>::Error,
-            <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,
     > {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -130,7 +130,7 @@ pub trait Step {
 ///
 /// The `Resources` type parameter defines the hardware resources required for
 /// motion control.
-pub trait EnableMotionControl<Resources> {
+pub trait EnableMotionControl<Resources, const TIMER_HZ: u32> {
     /// The type of the driver after motion control has been enabled
     type WithMotionControl: MotionControl;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -21,7 +21,7 @@
 //! [`Stepper`]: crate::Stepper
 
 use embedded_hal::digital::blocking::OutputPin;
-use embedded_time::duration::Nanoseconds;
+use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::step_mode::StepMode;
 


### PR DESCRIPTION
With all credit going to @ahdinosaur, this PR builds on top of #142 and supersedes it to replace `embedded-time` with `fugit`. It also ups use of `embedded-hal` to "=1.0.0-alpha.8" with associated changes to the introduced `ErrorTrait`. Lastly, due to breaking nature of changes, package versions are upped to `0.6.0`.
Thank you!