### PR TITLE
Upgrade to latest embedded-hal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ categories = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.9"
 fugit = "0.3.5"
 fugit-timer = "0.1.3"
 nb = "1.0.0"
@@ -36,7 +36,7 @@ paste = "1.0.3"
 ramp-maker = "0.2.0"
 
 [dependencies.embedded-hal-stable]
-version = "0.2.4"
+version = "0.2.7"
 package = "embedded-hal"
 
 [dependencies.num-traits]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -2,13 +2,13 @@
 
 use core::fmt;
 
-use embedded_hal::digital::blocking::OutputPin;
 use embedded_hal::digital::ErrorType;
+use embedded_hal::digital::OutputPin;
 use embedded_hal_stable::digital::v2::OutputPin as StableOutputPin;
 
 /// Wrapper around a pin
 ///
-/// Provides an implementation of [`embedded_hal::digital::blocking::OutputPin`]
+/// Provides an implementation of [`embedded_hal::digital::OutputPin`]
 /// (that is, the `OutputPin` from the latest alpha version of `embedded-hal`)
 /// for all types that implement `OutputPin` from the latest stable version of
 /// `embedded-hal`.

--- a/src/drivers/dq542ma.rs
+++ b/src/drivers/dq542ma.rs
@@ -11,7 +11,7 @@
 
 use core::convert::Infallible;
 
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal::digital::OutputPin;
 use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::traits::{

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -11,7 +11,7 @@
 
 use core::convert::Infallible;
 
-use embedded_hal::digital::{blocking::OutputPin, PinState};
+use embedded_hal::digital::{OutputPin, PinState};
 use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::{

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -11,7 +11,7 @@
 
 use core::convert::Infallible;
 
-use embedded_hal::digital::{blocking::OutputPin, PinState};
+use embedded_hal::digital::{OutputPin, PinState};
 use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! # impl embedded_hal::digital::ErrorType for Pin {
 //! #     type Error = core::convert::Infallible;
 //! # }
-//! # impl stepper::embedded_hal::digital::blocking::OutputPin for Pin {
+//! # impl stepper::embedded_hal::digital::OutputPin for Pin {
 //! #     fn set_low(&mut self) -> Result<(), Self::Error> { Ok(()) }
 //! #     fn set_high(&mut self) -> Result<(), Self::Error> { Ok(()) }
 //! # }

--- a/src/stepper/error.rs
+++ b/src/stepper/error.rs
@@ -69,7 +69,7 @@ pub enum SignalError<PinUnavailableError, PinError, TimerError> {
 
     /// An error originated from using the [`OutputPin`] trait
     ///
-    /// [`OutputPin`]: embedded_hal::digital::blocking::OutputPin
+    /// [`OutputPin`]: embedded_hal::digital::OutputPin
     Pin(PinError),
 
     /// An error originated from working with a timer

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -1,7 +1,7 @@
 use core::task::Poll;
 
-use embedded_hal::digital::blocking::OutputPin;
 use embedded_hal::digital::ErrorType;
+use embedded_hal::digital::OutputPin;
 use fugit::TimerDurationU32 as TimerDuration;
 use fugit_timer::Timer as TimerTrait;
 

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -1,7 +1,7 @@
 use core::task::Poll;
 
-use embedded_hal::digital::blocking::OutputPin;
 use embedded_hal::digital::ErrorType;
+use embedded_hal::digital::OutputPin;
 use fugit::TimerDurationU32 as TimerDuration;
 use fugit_timer::Timer as TimerTrait;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,7 +20,7 @@
 //!
 //! [`Stepper`]: crate::Stepper
 
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal::digital::OutputPin;
 use fugit::NanosDurationU32 as Nanoseconds;
 
 use crate::step_mode::StepMode;


### PR DESCRIPTION
Hi there,

I was working on a new driver for your framework (for the A4988), and I thought I'd get the `embedded-hal` dependencies on their most recent versions (`1.0.0-alpha.9` and `0.2.7`) to save you some trouble.

The changes required were pretty minor. Notably, `embedded-hal` now contains only blocking traits, and has changed their module paths to no longer reference `::blocking`.

https://github.com/rust-embedded/embedded-hal/blob/a55595cc80f19626f5db58abb6da619459064bf7/embedded-hal/CHANGELOG.md#changed

I'll follow this up with the driver code.  

Thanks! 